### PR TITLE
Disable e2e tests for master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.4.2
+  architect: giantswarm/architect@0.4.5
 
 e2eTest: &e2eTest
   machine: true
@@ -74,12 +74,8 @@ workflows:
     jobs:
       - build
 
-      - e2eTestBasic:
-          requires:
-            - build
-
       - architect/push-to-app-catalog:
-          name: "package and push metrics-server-app chart"
+          name: push-to-default-app-catalog
           app_catalog: "default-catalog"
           app_catalog_test: "default-test-catalog"
           chart: "metrics-server-app"
@@ -87,3 +83,12 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+
+      - e2eTestBasic:
+          requires:
+            - build
+            - push-to-default-app-catalog
+          filters:
+            branches:
+              ignore:
+                - master


### PR DESCRIPTION
Same issue as with https://github.com/giantswarm/node-exporter-app/pull/8, master branch e2e tests are failing https://circleci.com/gh/giantswarm/metrics-server-app/102 due to invalid use of default-test-catalog for all builds https://github.com/giantswarm/metrics-server-app/blob/master/.circleci/config.yml#L31

This PR works around the issue by disabling e2e tests for master branch.

Issue was uncovered while working on https://github.com/giantswarm/giantswarm/issues/6817