### PR TITLE
Bumped API version for `RoleBinding` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped API version for `RoleBinding` as it was using a deprecated version (removed in 1.22).
+
 ## [1.4.0] - 2021-08-13
 
 ## [1.3.0] - 2021-05-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Bumped API version for `RoleBinding` as it was using a deprecated version (removed in 1.22).
+- Bumped API version for `RoleBinding` to `v1` as it was using a deprecated version (removed in 1.22).
 
 ## [1.4.0] - 2021-08-13
 

--- a/helm/metrics-server-app/templates/rbac.yaml
+++ b/helm/metrics-server-app/templates/rbac.yaml
@@ -48,7 +48,7 @@ rules:
   - watch
 ---
 # API Server Extension Role binding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Values.name }}-auth-reader


### PR DESCRIPTION
RoleBinding v1beta1 was deprecated in 1.17 and removed in 1.22.
This PR bumps the API level to v1.

tested with a new install and an upgrade