### PR TITLE
Preferred address type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Set `kubelet-preferred-address-types` to `Hostname` on `AWS`.
+
 ## [1.6.0] - 2022-01-04
 
 ### Changed

--- a/helm/metrics-server-app/Chart.yaml
+++ b/helm/metrics-server-app/Chart.yaml
@@ -5,4 +5,5 @@ home: https://github.com/giantswarm/metrics-server-app
 name: metrics-server-app
 version: [[ .Version ]]
 annotations:
-  config.giantswarm.io/version: 1.x.x
+  config.giantswarm.io/version: metrics-server-add-provider
+#  config.giantswarm.io/version: 1.x.x

--- a/helm/metrics-server-app/Chart.yaml
+++ b/helm/metrics-server-app/Chart.yaml
@@ -5,5 +5,4 @@ home: https://github.com/giantswarm/metrics-server-app
 name: metrics-server-app
 version: [[ .Version ]]
 annotations:
-  config.giantswarm.io/version: metrics-server-add-provider
-#  config.giantswarm.io/version: 1.x.x
+  config.giantswarm.io/version: 1.x.x

--- a/helm/metrics-server-app/templates/deployment.yaml
+++ b/helm/metrics-server-app/templates/deployment.yaml
@@ -27,6 +27,12 @@ spec:
       containers:
         - name: metrics-server
           args:
+          # See https://github.com/giantswarm/giantswarm/issues/22150
+          {{- if eq .Values.provider "aws" }}
+          - --kubelet-preferred-address-types=Hostname,InternalIP,ExternalIP
+          {{- else }}
+          - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+          {{- end }}
           {{- range .Values.args }}
           - {{ . | quote }}
           {{- end }}

--- a/helm/metrics-server-app/values.yaml
+++ b/helm/metrics-server-app/values.yaml
@@ -64,3 +64,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# provider (aws|kvm|azure)
+# The provider that the cluster is running on.
+# This value is set automatically, Do not overwrite this value.
+provider: ""

--- a/helm/metrics-server-app/values.yaml
+++ b/helm/metrics-server-app/values.yaml
@@ -49,7 +49,6 @@ args:
   - --logtostderr
 # enable this if you have self-signed certificates, see: https://github.com/kubernetes-incubator/metrics-server
   - --kubelet-insecure-tls
-  - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
   - --kubelet-use-node-status-port
   - --cert-dir=/tmp
   - --secure-port=10443


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/22150

Set `kubelet-preferred-address-types` to `Hostname` on `AWS`.

Tested on AWS and Azure MCs and on AWS and Azure WCs