### PR TITLE
metrics-server 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Updated metrics-server version to 0.6.1.
+
 ## [1.7.0] - 2022-05-23
 
 ### Changed

--- a/helm/metrics-server-app/Chart.yaml
+++ b/helm/metrics-server-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.5.2
+appVersion: 0.6.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 home: https://github.com/giantswarm/metrics-server-app
 name: metrics-server-app

--- a/helm/metrics-server-app/templates/rbac.yaml
+++ b/helm/metrics-server-app/templates/rbac.yaml
@@ -11,7 +11,7 @@ rules:
     resources:
     - pods
     - nodes
-    - nodes/stats
+    - nodes/metrics
     - namespaces
     - configmaps
     verbs:

--- a/helm/metrics-server-app/values.yaml
+++ b/helm/metrics-server-app/values.yaml
@@ -42,7 +42,7 @@ apiService:
 image:
   registry: docker.io
   name: giantswarm/metrics-server
-  tag: v0.5.2
+  tag: v0.6.1
   pullPolicy: IfNotPresent
 
 args:


### PR DESCRIPTION
Breaking change:

Metrics Server now requires access to nodes/metrics RBAC resource instead of nodes/stats. No changes needed if you use official manifests, however please update RBAC resources if you just use Metrics Server image with custom manifests.

Issue: https://github.com/giantswarm/roadmap/issues/846