### PR TITLE
disable PSP for 1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Disable PSPs for k8s 1.25 and newer.
+
 ## [2.1.0] - 2023-04-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Disable PSPs for k8s 1.25 and newer.
+- Switch to `apiVersion: policy/v1` for PodDisruptionBudget.
 
 ## [2.1.0] - 2023-04-04
 

--- a/helm/metrics-server-app/templates/pdb.yaml
+++ b/helm/metrics-server-app/templates/pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ .Values.name }}

--- a/helm/metrics-server-app/templates/psp.yaml
+++ b/helm/metrics-server-app/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -27,3 +28,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/metrics-server-app/templates/psp.yaml
+++ b/helm/metrics-server-app/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
in k8s 1.25 there is no PodSecurityPolicy

this PR disables the PSP for 1.25