### PR TITLE
Allow override of hostNetwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add possibility to configure `hostNetwork`.
+
+### Changed
+
+- Upgrade metrics-server to v0.6.4.
+
 ## [2.3.1] - 2023-10-10
 
 ### Fixed

--- a/helm/metrics-server-app/Chart.yaml
+++ b/helm/metrics-server-app/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-appVersion: 0.6.1
+apiVersion: v2
+appVersion: 0.6.4
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 home: https://github.com/giantswarm/metrics-server-app
 name: metrics-server-app

--- a/helm/metrics-server-app/templates/deployment.yaml
+++ b/helm/metrics-server-app/templates/deployment.yaml
@@ -78,6 +78,7 @@ spec:
           volumeMounts:
           - mountPath: /tmp
             name: tmp-dir
+      hostNetwork: {{ .Values.hostNetwork }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}

--- a/helm/metrics-server-app/templates/kyverno-policy-exception.yaml
+++ b/helm/metrics-server-app/templates/kyverno-policy-exception.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.kyvernoPolicyExceptions.enabled .Values.hostNetwork }}
+{{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
+# This Kyverno policy exception is useful for metrics server on EKS cluster
+# where we currently have to use hostNetwork: true
+apiVersion: kyverno.io/v2alpha1
+kind: PolicyException
+metadata:
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: {{ .Values.name }}-exceptions
+  namespace: {{ .Values.kyvernoPolicyExceptions.namespace | default .Values.namespace }}
+spec:
+  exceptions:
+  - policyName: disallow-host-namespaces
+    ruleNames:
+    - host-namespaces
+    - autogen-host-namespaces
+  - policyName: disallow-host-ports
+    ruleNames:
+    - host-ports-none
+    - autogen-host-ports-none
+  match:
+    any:
+    - resources:
+        kinds:
+        - Deployment
+        - ReplicaSet
+        - Pod
+        namespaces:
+        - {{ .Values.namespace }}
+        names:
+        - {{ .Values.name }}*
+{{- end -}}
+{{- end -}}

--- a/helm/metrics-server-app/templates/psp.yaml
+++ b/helm/metrics-server-app/templates/psp.yaml
@@ -23,7 +23,10 @@ spec:
   - 'emptyDir'
   hostPID: false
   hostIPC: false
-  hostNetwork: false
+  hostNetwork: {{ .Values.hostNetwork }}
+  hostPorts:
+  - min: {{ .Values.port }}
+    max: {{ .Values.port }}
   fsGroup:
     rule: 'MustRunAs'
     ranges:

--- a/helm/metrics-server-app/values.schema.json
+++ b/helm/metrics-server-app/values.schema.json
@@ -73,8 +73,24 @@
         "extraArgs": {
             "type": "array"
         },
+        "global": {
+            "type": "object",
+            "properties": {
+                "podSecurityStandards": {
+                    "type": "object",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
         "groupID": {
             "type": "integer"
+        },
+        "hostNetwork": {
+            "type": "boolean"
         },
         "image": {
             "type": "object",
@@ -89,6 +105,17 @@
                     "type": "string"
                 },
                 "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "kyvernoPolicyExceptions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "namespace": {
                     "type": "string"
                 }
             }

--- a/helm/metrics-server-app/values.yaml
+++ b/helm/metrics-server-app/values.yaml
@@ -6,6 +6,10 @@ global:
   podSecurityStandards:
     enforced: false
 
+kyvernoPolicyExceptions:
+  enabled: true
+  namespace: giantswarm
+
 name: metrics-server
 namespace: kube-system
 serviceType: managed
@@ -46,7 +50,7 @@ apiService:
 image:
   registry: docker.io
   name: giantswarm/metrics-server
-  tag: v0.6.1
+  tag: v0.6.4
   pullPolicy: IfNotPresent
 
 args:
@@ -60,6 +64,7 @@ args:
 
 extraArgs: []
 
+hostNetwork: false
 priorityClassName: giantswarm-critical
 
 resources:


### PR DESCRIPTION
While investigating https://github.com/giantswarm/giantswarm/issues/28252, we discovered that there is an issue with cilium cni on EKS that prevents the metrics-server from working as expected (c.f. https://github.com/giantswarm/giantswarm/issues/28252#issuecomment-1755210020).

Until the team has the time to find out what is happening, we can use host network on metrics server