### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [2.4.1] - 2023-10-12
 
 ### Fixed

--- a/helm/metrics-server-app/values.yaml
+++ b/helm/metrics-server-app/values.yaml
@@ -44,7 +44,7 @@ apiService:
   insecureSkipTLSVerify: true
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   name: giantswarm/metrics-server
   tag: v0.6.4
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
