### PR TITLE
Chart: Update PolicyExceptions to v2beta1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add VPA setting for `metrics-server`.
+- Chart: Update PolicyExceptions to v2beta1. ([#226](https://github.com/giantswarm/metrics-server-app/pull/226))
 
 ## [2.4.2] - 2023-12-20
 

--- a/helm/metrics-server-app/templates/kyverno-policy-exception.yaml
+++ b/helm/metrics-server-app/templates/kyverno-policy-exception.yaml
@@ -1,8 +1,8 @@
 {{- if and .Values.kyvernoPolicyExceptions.enabled .Values.hostNetwork }}
-{{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
+{{- if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" -}}
 # This Kyverno policy exception is useful for metrics server on EKS cluster
 # where we currently have to use hostNetwork: true
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   annotations:


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.