### PR TITLE
update kyverno policy exception version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Update PolicyExceptions to v2.
+
 ## [2.6.0] - 2025-02-18
 
 ### Changed

--- a/helm/metrics-server-app/templates/kyverno-policy-exception.yaml
+++ b/helm/metrics-server-app/templates/kyverno-policy-exception.yaml
@@ -1,8 +1,8 @@
 {{- if and .Values.kyvernoPolicyExceptions.enabled .Values.hostNetwork }}
-{{- if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" -}}
+{{- if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" -}}
 # This Kyverno policy exception is useful for metrics server on EKS cluster
 # where we currently have to use hostNetwork: true
-apiVersion: kyverno.io/v2beta1
+apiVersion: kyverno.io/v2
 kind: PolicyException
 metadata:
   annotations:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/34101

This pull request updates the handling of Kyverno PolicyExceptions in the chart to use the new v2 API version. This change ensures compatibility with the latest Kyverno release and improves future maintainability.
