### PR TITLE
Update team annotation key to OpenContainers format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade metrics-server to v0.8.1.
+- Change team annotation in `Chart.yaml` to OpenContainers format (`io.giantswarm.application.team`).
+
 ## [2.7.0] - 2025-09-01
 
 ### Changed

--- a/helm/metrics-server-app/Chart.yaml
+++ b/helm/metrics-server-app/Chart.yaml
@@ -1,10 +1,9 @@
 apiVersion: v2
-appVersion: 0.7.2
+appVersion: v0.8.1
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
 home: https://github.com/giantswarm/metrics-server-app
 name: metrics-server-app
 version: 2.7.0
 icon: https://s.giantswarm.io/app-icons/k8s-initiator/1/dark.svg
 annotations:
-  config.giantswarm.io/version: 1.x.x
-  application.giantswarm.io/team: "atlas"
+  io.giantswarm.application.team: "atlas"

--- a/helm/metrics-server-app/templates/_helpers.tpl
+++ b/helm/metrics-server-app/templates/_helpers.tpl
@@ -22,7 +22,7 @@ app.kubernetes.io/name: {{ .Values.name }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | default "atlas" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | default "atlas" | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
 giantswarm.io/service-type: {{ .Values.serviceType }}
 {{- end -}}

--- a/helm/metrics-server-app/templates/deployment.yaml
+++ b/helm/metrics-server-app/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
           {{- range .Values.extraArgs }}
           - {{ . | quote }}
           {{- end }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             failureThreshold: 3

--- a/helm/metrics-server-app/values.yaml
+++ b/helm/metrics-server-app/values.yaml
@@ -46,7 +46,7 @@ apiService:
 image:
   registry: gsoci.azurecr.io
   name: giantswarm/metrics-server
-  tag: v0.7.2
+  tag: ""
   pullPolicy: IfNotPresent
 
 args:


### PR DESCRIPTION
Fixes https://github.com/giantswarm/roadmap/issues/4189

Update team annotation key to OpenContainers format (io.giantswarm.application.team) in both Chart.yaml and _helpers.tpl

Also bumps metrics-server to 0.8.1